### PR TITLE
add faster JVM baseline for MMM

### DIFF
--- a/src/ch/ethz/acl/ngen/mmm/BenchMMM.scala
+++ b/src/ch/ethz/acl/ngen/mmm/BenchMMM.scala
@@ -31,16 +31,24 @@ class BenchMMM extends Bench.ForkedTime {
   performance of "MMM" config (
     exec.minWarmupRuns -> 100,
     exec.maxWarmupRuns -> 100,
-    exec.independentSamples -> 1
+    exec.independentSamples -> 1,
+    exec.jvmflags -> List("-XX:-TieredCompilation", // ensure C2 is actually used
+                          "-XX:CompileThreshold=100" // the paper claims to set this
+    )
   ) in {
-    measure method "jMMM.blocked (JVM implementation)" in {
+    measure method "jMMM.fast (JVM implementation)" in {
       using(argsMMM) in {
-        case (a, b, c, size) => MMM.jMMM.blocked(a, b, c, size)
+        case (a, b, c, size) => MMM.jMMM.fast(a, b, c, size)
       }
     }
     measure method "nMMM.blocked (LMS generated)" in {
       using(argsMMM) in {
         case (a, b, c, size) => MMM.nMMM.blocked(a, b, c, size)
+      }
+    }
+    measure method "jMMM.blocked (JVM implementation)" in {
+      using(argsMMM) in {
+        case (a, b, c, size) => MMM.jMMM.blocked(a, b, c, size)
       }
     }
     measure method "jMMM.baseline (JVM implementation)" in {

--- a/src/ch/ethz/acl/ngen/mmm/JMMM.java
+++ b/src/ch/ethz/acl/ngen/mmm/JMMM.java
@@ -1,5 +1,7 @@
 package ch.ethz.acl.ngen.mmm;
 
+import java.util.Arrays;
+
 public class JMMM {
     //
     // Baseline implementation of a Matrix-Matrix-Multiplication
@@ -33,6 +35,30 @@ public class JMMM {
                     }
                 }
             }
+        }
+    }
+
+    public void fast(float[] a, float[] b, float[] c, int n) {
+        float[] bBuffer = new float[n];
+        float[] cBuffer = new float[n];
+        int in = 0;
+        for (int i = 0; i < n; ++i) {
+            int kn = 0;
+            for (int k = 0; k < n; ++k) {
+                float aik = a[in + k];
+                System.arraycopy(b, kn, bBuffer, 0, n);
+                saxpy(n, aik, bBuffer, cBuffer);
+                kn += n;
+            }
+            System.arraycopy(cBuffer, 0, c, in, n);
+            Arrays.fill(cBuffer, 0f);
+            in += n;
+        }
+    }
+
+    private void saxpy(int n, float aik, float[] b, float[] c) {
+        for (int i = 0; i < n; ++i) {
+            c[i] += aik * b[i];
         }
     }
 


### PR DESCRIPTION
Regarding the JVM flags: in **3.4 (Experimental Setup) > Evaluation** (page 7) you state that the forked JVM instance has `-XX:CompileThreshold=100` but don't actually do so in the benchmarks. The second JVM argument (`-XX:-TieredCompilation`) ensures you use C2 since I saw tiered compilation happening during the measurements without it. 

I also provide an example of a matrix multiplication implementation which performs about 6x better than the blocked algorithm used as a baseline, and better than the LMS generated code when the pair of matrices cannot reside fully in L3 cache. The implementation is slightly convoluted because it seems that the superword vectoriser in Hotspot bails when you evaluate SAXPY for offset slices of an array (this might be a bug, and if it is, it's still present in JDK9 and JDK10). Copying the slices into buffers enables the saxpy core loop to vectorise, yielding better throughput. In later JDK versions, this code uses the widest register width available and matches the throughput of LMS generated code. It's impossible to say how much LMS would profit from a JDK upgrade without upgrading scala-lang.virtualized.* to 2.12.*, however.

```
====================================================
Benchmarking MMM.jMMM.fast (JVM implementation)
----------------------------------------------------
    Size (N) | Flops / Cycle
----------------------------------------------------
           8 | 0.2500390686
          32 | 0.7710872405
          64 | 1.1302489072
         128 | 2.5113453810
         192 | 2.9525859816
         256 | 3.1180920385
         320 | 3.1081563593
         384 | 3.1458423577
         448 | 3.0493148252
         512 | 3.0551158263
         576 | 3.1430376938
         640 | 3.2169923048
         704 | 3.1026513283
         768 | 2.4190053777
         832 | 3.3358586705
         896 | 3.0755689237
         960 | 2.9996690697
        1024 | 2.2935654309
====================================================

====================================================
Benchmarking MMM.nMMM.blocked (LMS generated)
----------------------------------------------------
    Size (N) | Flops / Cycle
----------------------------------------------------
           8 | 1.0001562744
          32 | 5.3330416826
          64 | 5.8180867784
         128 | 5.1717318641
         192 | 5.1639907462
         256 | 4.3418618628
         320 | 5.2536572701
         384 | 4.0801359215
         448 | 4.1337007093
         512 | 3.2678160754
         576 | 3.7973028890
         640 | 3.3557513664
         704 | 4.0103133240
         768 | 3.4188362575
         832 | 3.2189488327
         896 | 3.2316685219
         960 | 2.9985655539
        1024 | 1.7750946796
====================================================

====================================================
Benchmarking MMM.jMMM.blocked (JVM implementation)
----------------------------------------------------
    Size (N) | Flops / Cycle
----------------------------------------------------
           8 | 0.5000781372
          32 | 0.6400028000
          64 | 0.5682568807
         128 | 0.5996199747
         192 | 0.6239961323
         256 | 0.5864838394
         320 | 0.5991560286
         384 | 0.5701005084
         448 | 0.5740271299
         512 | 0.5466428270
         576 | 0.5493065307
         640 | 0.5538750175
         704 | 0.5577268857
         768 | 0.5512993033
         832 | 0.5565532937
         896 | 0.5406809266
         960 | 0.5047555546
        1024 | 0.4042536740
====================================================

====================================================
Benchmarking MMM.jMMM.baseline (JVM implementation)
----------------------------------------------------
    Size (N) | Flops / Cycle
----------------------------------------------------
           8 | 0.3333854248
          32 | 0.5333379167
          64 | 0.6984999135
         128 | 0.6008512163
         192 | 0.5607890505
         256 | 0.5088439822
         320 | 0.5295694027
         384 | 0.4928785458
         448 | 0.5096290685
         512 | 0.3481941156
         576 | 0.5171241182
         640 | 0.4276359551
         704 | 0.4904493737
         768 | 0.4035653402
         832 | 0.4496286979
         896 | 0.3901097359
         960 | 0.4263629702
        1024 | 0.1689477908
====================================================
```